### PR TITLE
Fix timezone-naive datetime usage in standalone_controller.py

### DIFF
--- a/standalone_controller.py
+++ b/standalone_controller.py
@@ -3,6 +3,7 @@
 import os
 import time
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 from mister_controller import SwitchBotAPI, SmartHoseTimerAPI, SensorReading, MisterConfig
 from decision_engine import MistingDecisionEngine
@@ -123,7 +124,7 @@ class FinalMisterController:
                         
                         if self.rachio.start_watering(self.valve_id, self.config.mister_duration_seconds):
                             self.is_misting = True
-                            self.last_mister_start = datetime.now()
+                            self.last_mister_start = datetime.now(ZoneInfo("localtime"))
                             logger.info(f"✅ Mister started successfully for {self.config.mister_duration_seconds}s")
                         else:
                             logger.error("❌ Failed to start mister")
@@ -135,7 +136,7 @@ class FinalMisterController:
                         if reading.humidity > self.config.humidity_threshold_high:
                             reason.append("humidity increased")
                         if self.last_mister_start:
-                            runtime = (datetime.now() - self.last_mister_start).total_seconds()
+                            runtime = (datetime.now(ZoneInfo("localtime")) - self.last_mister_start).total_seconds()
                             if runtime >= self.config.mister_duration_seconds:
                                 reason.append("max duration")
                         
@@ -153,7 +154,7 @@ class FinalMisterController:
                         
                         if self.is_misting:
                             if self.last_mister_start:
-                                runtime = (datetime.now() - self.last_mister_start).total_seconds()
+                                runtime = (datetime.now(ZoneInfo("localtime")) - self.last_mister_start).total_seconds()
                                 remaining = self.config.mister_duration_seconds - runtime
                                 status_parts.append(f"💦 MISTING ({remaining:.0f}s left)")
                             else:
@@ -169,7 +170,7 @@ class FinalMisterController:
                             
                             # Cooldown info
                             if self.last_mister_start:
-                                cooldown_elapsed = (datetime.now() - self.last_mister_start).total_seconds()
+                                cooldown_elapsed = (datetime.now(ZoneInfo("localtime")) - self.last_mister_start).total_seconds()
                                 if cooldown_elapsed < self.config.cooldown_seconds:
                                     cooldown_remaining = self.config.cooldown_seconds - cooldown_elapsed
                                     status_parts.append(f"⏰ COOLDOWN ({cooldown_remaining:.0f}s)")


### PR DESCRIPTION
## Summary
- Fixes timezone-naive datetime calls in `standalone_controller.py` that were inconsistent with the rest of the application
- Adds `ZoneInfo` import and replaces all 4 instances of `datetime.now()` with `datetime.now(ZoneInfo("localtime"))`
- Ensures consistency with `api_server.py` and `state_manager.py` timezone handling

## Changes
- **standalone_controller.py:6**: Added `ZoneInfo` import
- **standalone_controller.py:127**: Made `last_mister_start` assignment timezone-aware
- **standalone_controller.py:139**: Made runtime calculation timezone-aware (stop logic)
- **standalone_controller.py:157**: Made runtime calculation timezone-aware (status reporting)
- **standalone_controller.py:173**: Made cooldown elapsed calculation timezone-aware

## Testing
- ✅ Python syntax validation passed
- ✅ Verified no remaining timezone-naive datetime.now() calls
- ✅ Aligns with timezone-aware pattern from commit afde8ad

## Impact
Fixes potential datetime comparison errors and ensures time calculations are correct across timezone changes (e.g., DST transitions).

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)