### PR TITLE
Remove unused RACHIO_BASE_STATION_ID environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   mister-controller:
@@ -15,7 +15,6 @@ services:
     environment:
       # Non-sensitive configuration (kept as environment variables)
       - HUB2_DEVICE_ID=${HUB2_DEVICE_ID}
-      - RACHIO_BASE_STATION_ID=${RACHIO_BASE_STATION_ID}
       - RACHIO_VALVE_ID=${RACHIO_VALVE_ID}
       - TEMP_HIGH=${TEMP_HIGH:-95}
       - TEMP_LOW=${TEMP_LOW:-95}


### PR DESCRIPTION
## Description
Removes unused `RACHIO_BASE_STATION_ID` environment variable from `docker-compose.yml`.

## Changes Made
- Removed `RACHIO_BASE_STATION_ID` environment variable definition from `docker-compose.yml` (line 15)

## Reasoning
- Variable was defined but never used in any Python files (`api_server.py`, `standalone_controller.py`, `mister_controller.py`)
- Rachio Smart Hose Timer API only requires valve ID for operations
- Reduces maintenance burden and potential confusion for developers

## Testing
- Verified the line was successfully removed
- No other references to this variable exist in the codebase

Fixes #47
